### PR TITLE
Set permission for token in unit test GA workflow

### DIFF
--- a/.github/workflows/run_full_test_suite.yml
+++ b/.github/workflows/run_full_test_suite.yml
@@ -3,6 +3,9 @@ name: Run Full Suite of Checks and Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
# PR Summary

Fences permissions of github token used for Github actions workflow that runs unit tests.

## Related Issue(s)

Fixes: #16
