### PR TITLE
Set hashes for github action versions in all workflows

### DIFF
--- a/.github/workflows/openssf_scorecard.yml
+++ b/.github/workflows/openssf_scorecard.yml
@@ -35,7 +35,7 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.2.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/openssf_scorecard.yml
+++ b/.github/workflows/openssf_scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@294a9d92911152fe08befb9ec03e240add280cb3  # v3.26.8-64431c66d
         with:
           sarif_file: results.sarif

--- a/.github/workflows/run_full_test_suite.yml
+++ b/.github/workflows/run_full_test_suite.yml
@@ -27,17 +27,17 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           fetch-depth: 0
 
       - name: Setup python for test - ${{ matrix.py }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
         with:
           python-version: ${{ matrix.py }}
       
       - name: Setup ffmpeg for unit tests (moviepy)
-        uses: federicocarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6
+        uses: federicocarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6  # v3.1
 
       - name: Install tox
         run: python -m pip install tox-gh>=1.2


### PR DESCRIPTION
# PR Summary

For increases security, all imported github action workflows have their commit has set as the version.

See https://github.com/magneticstain/plexer/security/code-scanning/3