### PR TITLE
Add GA workflow for building and uploading to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    # run only against version tags
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    # ensure only tagged commits get uploaded to PyPI
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
+    name: Generate New Release - ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      contents: write  # needed to create GH Release
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing to PyPI
+    
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Setup python for build
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
+        with:
+          python-version: "3.12"
+
+      # run unit tests
+      - name: Install tox
+        run: python -m pip install tox-gh>=1.2
+
+      - name: Setup test suite
+        run: tox -vv --notest -e test
+
+      - name: Run test suite
+        run: tox --skip-pkg-install -e test
+      
+      # build and publish
+      - name: Install Hatch
+        run: pipx install hatch
+
+      - name: Build dist artifacts
+        run: hatch build
+      
+      # required instead of using hatch due to usage of trusted publishers
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@897895f1e160c830e369f9779632ebc134688e1b  # v1.10.2
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          print-hash: true
+
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@897895f1e160c830e369f9779632ebc134688e1b  # v1.10.2
+      #   with:
+      #     attestations: true
+      


### PR DESCRIPTION
# PR Summary

Add Github Actions workflow that runs unit tests, builds the sdist and wheel packages, and uploads them to PyPI.

Only TestPyPI for now.

## Related Issue(s)

Related to: #3 