### PR TITLE
Add github action workflow for automatically creating Github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   release:
-    # ensure only tagged commits get uploaded to PyPI
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-
     name: Generate New Release - ${{ github.ref_name }}
     runs-on: ubuntu-latest
     environment: release
@@ -27,9 +24,9 @@ jobs:
       - name: Setup python for build
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.x"
 
-      # run unit tests
+      # run tests
       - name: Install tox
         run: python -m pip install tox-gh>=1.2
 
@@ -46,6 +43,18 @@ jobs:
       - name: Build dist artifacts
         run: hatch build
       
+      # Github Release
+      - name: Create Github Release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
+        with:
+          name: 
+          files: |
+            dist/*
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          make_latest: true
+      
+      # PyPI Release
       # required instead of using hatch due to usage of trusted publishers
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@897895f1e160c830e369f9779632ebc134688e1b  # v1.10.2


### PR DESCRIPTION
# PR Summary

Github Actions workflow was added to release yaml to automatically create a new Github Release when a tag is pushed. This happens right before the push to PyPI

## Related Issue(s)

Related to: Issue #27
